### PR TITLE
Limited length of messages label for better readability

### DIFF
--- a/frontend/msc-drawer/script/poll.js
+++ b/frontend/msc-drawer/script/poll.js
@@ -27,7 +27,16 @@ function poll(){
           entryCounter = data.length;
           console.log("Entry changed");
           for(i = 0; i < data.length; i++){
-            chart += escapeDiagramString(data[i].from) + "->" + escapeDiagramString(data[i].to) + ":" + escapeDiagramString(data[i].label);
+            var MAX_LABEL_LEN = 60;
+            var str_len = data[i].label.length;
+            var label = data[i].label;
+            if (str_len > MAX_LABEL_LEN) {
+              var left = label.substring(0,MAX_LABEL_LEN/2);
+              var right = label.substring(str_len - MAX_LABEL_LEN/2, str_len);
+              label = left + "..." + right;
+            }
+
+            chart += escapeDiagramString(data[i].from) + "->" + escapeDiagramString(data[i].to) + ":" + escapeDiagramString(label);
             if(data[i].params.length > 0) {
               paramsList = "";
               // jsonParams = JSON.parse(data[i].params)


### PR DESCRIPTION
In certain scenarios the label of the message in the MSC is way too long, making reading the MSC very difficult. I added a limit of 60 chars to the label, keeping the first and last part and cutting in the middle.